### PR TITLE
Update skill.edn

### DIFF
--- a/skill.edn
+++ b/skill.edn
@@ -37,7 +37,7 @@
    :description "sync dependencies for one Repository",
    :pattern "^npm sync.*$"}],
  :iconUrl
- "https://raw.githubusercontent.com/cljs/logo/master/cljs.png",
+ "file://docs/images/icon.svg",
  :runtime
  {:name "nodejs10",
   :entry_point "eventhandler",


### PR DESCRIPTION
Add npm icon.

@slimslenderslacks I don't know if the `file://docs/images/icon.svg` reference for `iconUrl` will work here. I followed the pattern used in the [npm audit](https://github.com/atomist-skills/npm-audit-skill/blob/9a1727d4c0be74df27347544b434f069fd427790/skill.ts#L40) skill